### PR TITLE
[UPDATE] Re-include DC actions, but ignore others specific to zone/site tasks.

### DIFF
--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -28,9 +28,13 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	call vn_mf_fnc_action_capture_player;
 	//call vn_mf_fnc_action_arrest_player;
 	//call vn_mf_fnc_release_from_arrest_player;
+	/*
+	disabled by @dijksterhuis for curators
+
 	call vn_mf_fnc_action_destroy_task;
 	call vn_mf_fnc_action_gather_intel;
 	call vn_mf_fnc_action_radiotap;
+	*/
 	"vn_holdActionAdd_layer" cutText ["","PLAIN"];
 };
 

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -87,10 +87,7 @@ progressLoadingScreen 0.48;
 uiSleep 0.4;
 progressLoadingScreen 0.5;
 
-/*
-@dijksterhuis disabled for curator events
 ["action_manager", vn_mf_fnc_action_init, [], 5] call para_g_fnc_scheduler_add_job;
-*/
 
 [parseText format["<t font='tt2020base_vn' color='#F5F2D0'>%1</t>",localize "STR_vn_mf_loading11"]] call vn_mf_fnc_update_loading_screen;
 


### PR DESCRIPTION
Players should now be able to capture each other and destroy DC respawns.

Reading intel, wiretapping a radioset and destroying a site objective object are disabled.